### PR TITLE
Reset frame time when Composable's lifecycle is resumed

### DIFF
--- a/confettikit/build.gradle.kts
+++ b/confettikit/build.gradle.kts
@@ -47,6 +47,7 @@ kotlin {
             implementation(compose.runtime)
             implementation(compose.foundation)
             implementation(compose.ui)
+            implementation(libs.androidx.lifecycle.runtime.compose)
 
             // Kotlinx
             api(libs.kotlinx.datetime)

--- a/confettikit/src/commonMain/kotlin/io/github/vinceglb/confettikit/compose/ConfettiKit.kt
+++ b/confettikit/src/commonMain/kotlin/io/github/vinceglb/confettikit/compose/ConfettiKit.kt
@@ -11,6 +11,8 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.drawscope.withTransform
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import io.github.vinceglb.confettikit.core.Particle
 import io.github.vinceglb.confettikit.core.Party
 import io.github.vinceglb.confettikit.core.PartySystem
@@ -43,6 +45,9 @@ public fun ConfettiKit(
 
     val density = LocalDensity.current
 
+    LifecycleEventEffect(event = Lifecycle.Event.ON_RESUME) {
+        frameTime.value = 0L
+    }
     LaunchedEffect(Unit) {
         partySystems = parties.map {
             PartySystem(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,10 +8,12 @@ compose-multiplatform = "1.7.3"
 kotlin = "2.1.20"
 kotlinx-datetime = "0.6.2"
 vanniktech-mavenPublish = "0.31.0"
+androidx-lifecycle = "2.8.4"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
+androidx-lifecycle-runtime-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This prevents the delta from the previous frame time til now being so large that we render an inordinate amount of particles, slowing down or even crashing the app by running out of memory.

[Same issue as exists in the base repository](https://github.com/DanielMartinus/Konfetti/pull/342), figured I'd offer a fix here as well 😄 