### PR TITLE
Add parameter to tweak duration of fade out effect

### DIFF
--- a/confettikit/src/commonMain/kotlin/io/github/vinceglb/confettikit/core/Party.kt
+++ b/confettikit/src/commonMain/kotlin/io/github/vinceglb/confettikit/core/Party.kt
@@ -26,7 +26,7 @@ import io.github.vinceglb.confettikit.core.models.Size
  * @property timeToLive the amount of time in milliseconds before a particle will stop rendering
  * or fade out if [fadeOutEnabled] is set to true.
  * @property fadeOutEnabled If true and a confetti disappears because it ran out of time (set with timeToLive)
- * it will slowly fade out. If set to falls it will instantly disappear from the screen.
+ * it will slowly fade out. If set to false it will instantly disappear from the screen.
  * @property position the point where the confetti will spawn relative to the canvas. Use absolute
  * coordinates with [Position.Absolute] or relative coordinates between 0.0 and 1.0 using [Position.Relative].
  * Spawn confetti on random positions using [Position.Between].

--- a/confettikit/src/commonMain/kotlin/io/github/vinceglb/confettikit/core/Party.kt
+++ b/confettikit/src/commonMain/kotlin/io/github/vinceglb/confettikit/core/Party.kt
@@ -27,6 +27,7 @@ import io.github.vinceglb.confettikit.core.models.Size
  * or fade out if [fadeOutEnabled] is set to true.
  * @property fadeOutEnabled If true and a confetti disappears because it ran out of time (set with timeToLive)
  * it will slowly fade out. If set to false it will instantly disappear from the screen.
+ * @property fadeOutDuration the duration of the fade out effect, only used if [fadeOutEnabled] is set to true.
  * @property position the point where the confetti will spawn relative to the canvas. Use absolute
  * coordinates with [Position.Absolute] or relative coordinates between 0.0 and 1.0 using [Position.Relative].
  * Spawn confetti on random positions using [Position.Between].
@@ -49,6 +50,7 @@ public data class Party(
     val shapes: List<Shape> = listOf(Shape.Square, Shape.Circle),
     val timeToLive: Long = 2000,
     val fadeOutEnabled: Boolean = true,
+    val fadeOutDuration: Long = 850,
     val position: Position = Position.Relative(0.5, 0.5),
     val delay: Int = 0,
     val rotation: Rotation = Rotation(),

--- a/confettikit/src/commonMain/kotlin/io/github/vinceglb/confettikit/core/emitter/Confetti.kt
+++ b/confettikit/src/commonMain/kotlin/io/github/vinceglb/confettikit/core/emitter/Confetti.kt
@@ -14,8 +14,8 @@ import kotlin.math.abs
  * @property width The width of the particle in pixels.
  * @property mass The mass of the particle, affecting how forces like gravity influence it. A particle with more mass will move slower under the same force.
  * @property shape The geometric shape of the particle.
- * @property lifespan The duration the particle should exist for in milliseconds.
- * @property fadeOut If true, the particle will gradually become transparent over its lifespan.
+ * @property lifespan The duration the particle should be fully visible (opaque) for in milliseconds.
+ * @property fadeOut If true, the particle will gradually become transparent after its lifespan has elapsed.
  * @property acceleration The current acceleration of the particle.
  * @property velocity The current velocity of the particle.
  * @property damping A factor that reduces the particle's velocity over time, simulating air resistance. A higher damping value will slow down the particle faster.

--- a/confettikit/src/commonMain/kotlin/io/github/vinceglb/confettikit/core/emitter/Confetti.kt
+++ b/confettikit/src/commonMain/kotlin/io/github/vinceglb/confettikit/core/emitter/Confetti.kt
@@ -42,6 +42,7 @@ internal class Confetti(
         private const val DEFAULT_FRAME_RATE = 60f
         private const val GRAVITY = 0.02f
         private const val ALPHA_DECREMENT = 5
+        private const val MAX_ALPHA = 255
         private const val MILLIS_IN_SECOND = 1000
         private const val FULL_CIRCLE = 360f
     }
@@ -53,7 +54,7 @@ internal class Confetti(
     private var frameRate = DEFAULT_FRAME_RATE
     private var gravity = Vector(0f, GRAVITY)
 
-    var alpha: Int = 255
+    var alpha: Int = MAX_ALPHA
     var scaleX = 0f
 
     /**

--- a/confettikit/src/commonMain/kotlin/io/github/vinceglb/confettikit/core/emitter/PartyEmitter.kt
+++ b/confettikit/src/commonMain/kotlin/io/github/vinceglb/confettikit/core/emitter/PartyEmitter.kt
@@ -86,6 +86,7 @@ internal class PartyEmitter(
                 color = colors[random.nextInt(colors.size)],
                 lifespan = timeToLive,
                 fadeOut = fadeOutEnabled,
+                fadeOutDuration = fadeOutDuration,
                 velocity = getVelocity(),
                 damping = party.damping,
                 rotationSpeed2D = rotation.rotationSpeed() * party.rotation.multiplier2D,


### PR DESCRIPTION
I am using this library to create a more fireworks-like effect. It looks nice, except for the duration.
I think this parameter is something more devs would like to tweak, so I decided to add it to the library.

Note that in the previous code, the fade out duration was different based on the number of frames per second: it worked by decreasing the alpha (255 at start) by 5 every update, so 51 updates. For the default of 60 fps, this results in 51/60 or 850 ms fade out duration. So I took 850 ms as the default value. With this new code, the fade out duration will be the same regardless of fps, which I think is better. It is also in line with the `timeToLive` parameter.