### PR TITLE
✨ Introduce ConfettiKitState for hoisted animation control

### DIFF
--- a/confettikit/src/commonMain/kotlin/io/github/vinceglb/confettikit/compose/ConfettiKit.kt
+++ b/confettikit/src/commonMain/kotlin/io/github/vinceglb/confettikit/compose/ConfettiKit.kt
@@ -4,8 +4,10 @@ import androidx.compose.animation.core.withInfiniteAnimationFrameMillis
 import androidx.compose.foundation.Canvas
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.drawscope.withTransform
@@ -18,18 +20,17 @@ import io.github.vinceglb.confettikit.core.Party
 import io.github.vinceglb.confettikit.core.PartySystem
 import io.github.vinceglb.confettikit.core.models.CoreRect
 import io.github.vinceglb.confettikit.core.models.Shape
-import kotlin.time.Clock
-import kotlin.time.ExperimentalTime
+
+private const val SUB_STEP_MS = 16L
 
 @Composable
 public fun ConfettiKit(
     modifier: Modifier = Modifier,
     parties: List<Party>,
+    state: ConfettiKitState = rememberConfettiKitState(),
     onParticleSystemStarted: (PartySystem, Int) -> Unit = { _, _ -> },
     onParticleSystemEnded: (PartySystem, Int) -> Unit = { _, _ -> },
 ) {
-    lateinit var partySystems: List<PartySystem>
-
     /**
      * Particles to draw
      */
@@ -47,56 +48,121 @@ public fun ConfettiKit(
 
     val density = LocalDensity.current
 
-    // To prevent multiple callbacks for the same event on each frame
-    val startedSystems = remember { mutableSetOf<PartySystem>() }
-    val endedSystems = remember { mutableSetOf<PartySystem>() }
+    // Capture the latest callbacks so the long-running frame loop always invokes the most
+    // recent versions even when the caller rebuilds them across compositions.
+    val currentOnStarted by rememberUpdatedState(onParticleSystemStarted)
+    val currentOnEnded by rememberUpdatedState(onParticleSystemEnded)
 
     LifecycleEventEffect(event = Lifecycle.Event.ON_RESUME) {
         frameTime.value = 0L
     }
-    LaunchedEffect(Unit) {
-        partySystems = parties.map {
+    // Keying on `parties` makes the frame loop relaunch with the freshly-captured list when
+    // the caller swaps presets — without this, rapid taps could rebuild against a stale value
+    // because reads from a State object updated by the same recomposition can race against
+    // the frame callback. Callers should pass a stable list (the sample uses `remember(index)`)
+    // since `EmitterConfig` and custom shapes may rely on referential equality. Reset-driven
+    // rebuilds (state.reset()) are handled inside the loop on the resetSignal so scrubbing
+    // doesn't tear down the coroutine.
+    LaunchedEffect(state, parties) {
+        var partySystems = parties.map {
             PartySystem(
                 party = storeImages(it),
                 pixelDensity = density.density,
+                random = state.random,
             )
         }
-        startedSystems.clear()
-        endedSystems.clear()
+        // Logical timeline at which each system was first considered for emission.
+        // -1 means "not started yet". Initialized lazily once timelineMs has advanced.
+        var systemStartTimelineMs = LongArray(partySystems.size) { -1L }
+        // To prevent multiple callbacks for the same event on each frame
+        val startedSystems = mutableSetOf<PartySystem>()
+        val endedSystems = mutableSetOf<PartySystem>()
+        var lastResetSignal = state.resetSignal.intValue
+
+        frameTime.value = 0L
+        // Drop any frame still painted from a previous preset so the swap doesn't briefly
+        // show stale particles on top of the freshly-built systems.
+        particles.value = emptyList()
 
         while (true) {
             withInfiniteAnimationFrameMillis { frameMs ->
-                // Calculate time between frames, fallback to 0 when previous frame doesn't exist
-                val deltaMs = if (frameTime.value > 0) (frameMs - frameTime.value) else 0
+                val signal = state.resetSignal.intValue
+                if (signal != lastResetSignal) {
+                    partySystems = parties.map {
+                        PartySystem(
+                            party = storeImages(it),
+                            pixelDensity = density.density,
+                            random = state.random,
+                        )
+                    }
+                    systemStartTimelineMs = LongArray(partySystems.size) { -1L }
+                    startedSystems.clear()
+                    endedSystems.clear()
+                    particles.value = emptyList()
+                    lastResetSignal = signal
+                    frameTime.value = 0L
+                }
+
+                val realDeltaMs = if (frameTime.value > 0) (frameMs - frameTime.value) else 0L
                 frameTime.value = frameMs
 
-                particles.value = partySystems.map { particleSystem ->
-                    val totalTimeRunning = getTotalTimeRunning(particleSystem.createdAt)
-                    // Do not start particleSystem yet if totalTimeRunning is below delay
-                    if (totalTimeRunning < particleSystem.party.delay) return@map listOf()
+                val pending = state.takePendingAdvance()
+                val effectiveMs = (if (state.isPaused) 0L else realDeltaMs) + pending
 
-                    if (particleSystem !in startedSystems) {
-                        onParticleSystemStarted(
-                            particleSystem,
-                            partySystems.count {
-                                getTotalTimeRunning(it.createdAt) >= it.party.delay && !it.isDoneEmitting()
-                            },
-                        )
-                        startedSystems.add(particleSystem)
-                    }
+                if (effectiveMs <= 0L) {
+                    // No time advance; particles list is unchanged. Drawing the previous list
+                    // freezes the current visual state.
+                    return@withInfiniteAnimationFrameMillis
+                }
 
-                    if (particleSystem.isDoneEmitting()) {
-                        if (particleSystem !in endedSystems) {
-                            onParticleSystemEnded(
-                                particleSystem,
-                                partySystems.count { !it.isDoneEmitting() },
-                            )
-                            endedSystems.add(particleSystem)
+                // Sub-step large effective deltas (e.g. a manual seek) into ~16 ms chunks so
+                // that physics, damping and emission timing stay consistent with normal playback.
+                // Track the timeline locally and publish ONCE per frame at the end — a 1 s scrub
+                // would otherwise produce ~62 snapshot writes to `timelineMs`, invalidating
+                // every state reader (slider, label, etc.) once per sub-step.
+                val startTimelineMs = state.timelineMs
+                var localTimelineMs = startTimelineMs
+                var remaining = effectiveMs
+                var lastParticles: List<Particle> = emptyList()
+                while (remaining > 0L) {
+                    val stepMs = remaining.coerceAtMost(SUB_STEP_MS)
+                    localTimelineMs += stepMs
+                    remaining -= stepMs
+                    val stepSeconds = stepMs / 1000f
+
+                    lastParticles = partySystems.mapIndexed { index, particleSystem ->
+                        if (systemStartTimelineMs[index] < 0L) {
+                            systemStartTimelineMs[index] = localTimelineMs - stepMs
                         }
-                    }
+                        val totalTimeRunning = localTimelineMs - systemStartTimelineMs[index]
+                        if (totalTimeRunning < particleSystem.party.delay) return@mapIndexed listOf()
 
-                    particleSystem.render(deltaMs.div(1000f), drawArea.value)
-                }.flatten()
+                        if (particleSystem !in startedSystems) {
+                            val activeCount = partySystems.indices.count { i ->
+                                val started = systemStartTimelineMs[i]
+                                started >= 0L &&
+                                        (localTimelineMs - started) >= partySystems[i].party.delay &&
+                                        !partySystems[i].isDoneEmitting()
+                            }
+                            currentOnStarted(particleSystem, activeCount)
+                            startedSystems.add(particleSystem)
+                        }
+
+                        if (particleSystem.isDoneEmitting()) {
+                            if (particleSystem !in endedSystems) {
+                                currentOnEnded(
+                                    particleSystem,
+                                    partySystems.count { !it.isDoneEmitting() },
+                                )
+                                endedSystems.add(particleSystem)
+                            }
+                        }
+
+                        particleSystem.render(stepSeconds, drawArea.value)
+                    }.flatten()
+                }
+                state.advanceTimeline(localTimelineMs - startTimelineMs)
+                particles.value = lastParticles
             }
         }
     }
@@ -148,10 +214,4 @@ internal fun storeImages(
 ): Party {
     val transformedShapes = party.shapes.map { shape -> shape }
     return party.copy(shapes = transformedShapes)
-}
-
-@OptIn(ExperimentalTime::class)
-internal fun getTotalTimeRunning(startTime: Long): Long {
-    val currentTime = Clock.System.now().toEpochMilliseconds()
-    return (currentTime - startTime)
 }

--- a/confettikit/src/commonMain/kotlin/io/github/vinceglb/confettikit/compose/ConfettiKitState.kt
+++ b/confettikit/src/commonMain/kotlin/io/github/vinceglb/confettikit/compose/ConfettiKitState.kt
@@ -11,6 +11,15 @@ import kotlin.random.Random
 /**
  * Creates and remembers a [ConfettiKitState] for use with [ConfettiKit].
  *
+ * @param initiallyPaused if `true`, the simulation starts in the paused state. Pair with
+ * [initialTimelineMs] to render a single static frame at a known timestamp. Defaults to `false`
+ * (live playback).
+ * @param initialTimelineMs an initial advance, in milliseconds, queued for the first frame.
+ * The simulation is actually run forward by this amount (sub-stepped like a manual scrub), so
+ * the resulting frame matches what you would have seen at that timestamp during live playback.
+ * Most useful with `initiallyPaused = true` for previews. With live playback, the entire
+ * advance is consumed in the first frame, which can look like a sudden fast-forward.
+ * Defaults to `0`.
  * @param random factory invoked to obtain the [Random] instance handed to each [io.github.vinceglb.confettikit.core.PartySystem].
  * The factory is called once on creation and again on every [ConfettiKitState.reset] so that callers
  * who pass `{ Random(seed) }` get reproducible playback. The default `{ Random.Default }` matches the
@@ -18,8 +27,10 @@ import kotlin.random.Random
  */
 @Composable
 public fun rememberConfettiKitState(
+    initiallyPaused: Boolean = false,
+    initialTimelineMs: Long = 0L,
     random: () -> Random = { Random.Default },
-): ConfettiKitState = remember { ConfettiKitState(random) }
+): ConfettiKitState = remember { ConfettiKitState(initiallyPaused, initialTimelineMs, random) }
 
 /**
  * Hoisted state for [ConfettiKit] that exposes a more granular API for animation control.
@@ -34,11 +45,19 @@ public fun rememberConfettiKitState(
  */
 @Stable
 public class ConfettiKitState internal constructor(
+    initiallyPaused: Boolean = false,
+    initialTimelineMs: Long = 0L,
     initialRandomFactory: () -> Random,
 ) {
-    private val pausedState = mutableStateOf(false)
+    init {
+        require(initialTimelineMs >= 0L) {
+            "initialTimelineMs must be non-negative, was $initialTimelineMs"
+        }
+    }
+
+    private val pausedState = mutableStateOf(initiallyPaused)
     private val timelineMsState = mutableLongStateOf(0L)
-    private var pendingAdvanceMs: Long = 0L
+    private var pendingAdvanceMs: Long = initialTimelineMs
 
     private var randomFactory: () -> Random = initialRandomFactory
 

--- a/confettikit/src/commonMain/kotlin/io/github/vinceglb/confettikit/compose/ConfettiKitState.kt
+++ b/confettikit/src/commonMain/kotlin/io/github/vinceglb/confettikit/compose/ConfettiKitState.kt
@@ -1,0 +1,185 @@
+package io.github.vinceglb.confettikit.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import kotlin.random.Random
+
+/**
+ * Creates and remembers a [ConfettiKitState] for use with [ConfettiKit].
+ *
+ * @param random factory invoked to obtain the [Random] instance handed to each [io.github.vinceglb.confettikit.core.PartySystem].
+ * The factory is called once on creation and again on every [ConfettiKitState.reset] so that callers
+ * who pass `{ Random(seed) }` get reproducible playback. The default `{ Random.Default }` matches the
+ * pre-existing behavior (the singleton [Random] companion is used as-is).
+ */
+@Composable
+public fun rememberConfettiKitState(
+    random: () -> Random = { Random.Default },
+): ConfettiKitState = remember { ConfettiKitState(random) }
+
+/**
+ * Hoisted state for [ConfettiKit] that exposes a more granular API for animation control.
+ *
+ * Following the same pattern as `LazyListState` / `ScrollState`, this object lets callers:
+ * - Inject a deterministic [Random] (via `random` factory) so confetti can be reproduced.
+ * - Pause and resume the simulation without unmounting the composable.
+ * - Advance the simulation by a manual delta to scrub or freeze a "keyframe".
+ * - Reset the timeline back to `t=0`, re-creating particles with a fresh [Random].
+ *
+ * All mutating methods are safe to call from the UI thread / composition.
+ */
+@Stable
+public class ConfettiKitState internal constructor(
+    initialRandomFactory: () -> Random,
+) {
+    private val pausedState = mutableStateOf(false)
+    private val timelineMsState = mutableLongStateOf(0L)
+    private var pendingAdvanceMs: Long = 0L
+
+    private var randomFactory: () -> Random = initialRandomFactory
+
+    /**
+     * Reset signal observed by the composable as a [androidx.compose.runtime.LaunchedEffect] key.
+     * Every increment causes the underlying [io.github.vinceglb.confettikit.core.PartySystem]s to
+     * be re-created with a fresh [Random] from the current factory.
+     */
+    internal val resetSignal = mutableIntStateOf(0)
+
+    /**
+     * The [Random] instance currently in use. Replaced on every [reset] by invoking the current
+     * random factory (either the one passed to [rememberConfettiKitState] or the latest one set
+     * via [useRandom]).
+     */
+    public var random: Random = randomFactory()
+        internal set
+
+    /**
+     * Whether the simulation is paused. While paused, real frame deltas are ignored and only
+     * manual [advance] calls cause the simulation to progress.
+     */
+    public var isPaused: Boolean
+        get() = pausedState.value
+        set(value) {
+            pausedState.value = value
+        }
+
+    /**
+     * Logical elapsed time in milliseconds. Increments only when the simulation advances —
+     * i.e., real frame deltas while not paused, plus any [advance] calls.
+     */
+    public val timelineMs: Long
+        get() = timelineMsState.longValue
+
+    /** Pause the simulation. Equivalent to `isPaused = true`. */
+    public fun pause() {
+        isPaused = true
+    }
+
+    /** Resume the simulation. Equivalent to `isPaused = false`. */
+    public fun resume() {
+        isPaused = false
+    }
+
+    /**
+     * Queue an additional [deltaMs] milliseconds to be applied on the next frame. The delta is
+     * applied regardless of [isPaused], which makes this the primary tool for manual scrubbing
+     * while paused.
+     *
+     * Large deltas are sub-stepped internally by the composable into small chunks so that
+     * physics remain stable.
+     */
+    public fun advance(deltaMs: Long) {
+        require(deltaMs >= 0L) { "deltaMs must be non-negative, was $deltaMs" }
+        pendingAdvanceMs += deltaMs
+    }
+
+    /**
+     * Seek the timeline to [targetMs]. The target is compared against the *effective* position
+     * `timelineMs + pendingAdvanceMs` — where the timeline will be after the next frame applies
+     * any queued advance.
+     *
+     * - **Forward** (target ≥ effective): queue the delta via [advance].
+     * - **Backward but absorbable** (target < effective and the gap fits within the queued
+     *   advance): trim [pendingAdvanceMs] in place. This handles rapid scrubbing where slider
+     *   events outpace frames — multiple `advanceTo` calls between frames may queue more advance
+     *   than the user ultimately wants, and we just shave it back. Nothing is committed yet, so
+     *   no reset is needed.
+     * - **Backward beyond what's queued** (the user wants to land before [timelineMs]): the
+     *   committed timeline can only be wound back by tearing it down, so [reset] and replay
+     *   forward to [targetMs]. Particles re-emit from t=0 using the same factory-derived
+     *   [Random], which keeps seeded scrubbing deterministic.
+     */
+    public fun advanceTo(targetMs: Long) {
+        require(targetMs >= 0L) { "targetMs must be non-negative, was $targetMs" }
+        val effectivePosition = timelineMs + pendingAdvanceMs
+        val backward = effectivePosition - targetMs
+        when {
+            backward <= 0L -> {
+                val needed = -backward
+                if (needed > 0L) advance(needed)
+            }
+
+            backward <= pendingAdvanceMs -> {
+                pendingAdvanceMs -= backward
+            }
+
+            else -> {
+                reset()
+                if (targetMs > 0L) advance(targetMs)
+            }
+        }
+    }
+
+    /**
+     * Reset the timeline to `0`, drop any pending advance, and signal the composable to
+     * re-create its [io.github.vinceglb.confettikit.core.PartySystem]s using a fresh [Random]
+     * from the current random factory.
+     *
+     * For seeded factories like `{ Random(42L) }` this means subsequent playback is identical
+     * to the original run.
+     */
+    public fun reset() {
+        pendingAdvanceMs = 0L
+        timelineMsState.longValue = 0L
+        random = randomFactory()
+        resetSignal.intValue++
+    }
+
+    /**
+     * Replace the random factory and immediately [reset] the simulation. Use this to switch
+     * between a seeded `{ Random(seed) }` factory for reproducible playback and
+     * `{ Random.Default }` for live randomness without having to recreate the state object.
+     */
+    public fun useRandom(factory: () -> Random) {
+        randomFactory = factory
+        reset()
+    }
+
+    /**
+     * Replace the random factory used by future [reset] calls without resetting the running
+     * simulation. The currently-running [random] instance and any in-flight particles keep
+     * their existing source — only the *next* [reset] will pull from the new factory.
+     *
+     * Useful when toggling out of a deterministic-scrubbing mode: you want subsequent restarts
+     * to use live randomness, but you don't want the current paused frame to be wiped.
+     */
+    public fun setRandomFactory(factory: () -> Random) {
+        randomFactory = factory
+    }
+
+    /** Consume any pending manual advance; returns the value and zeros it out. */
+    internal fun takePendingAdvance(): Long {
+        val v = pendingAdvanceMs
+        pendingAdvanceMs = 0L
+        return v
+    }
+
+    /** Increment the logical timeline by [deltaMs]. Called by the composable's frame loop. */
+    internal fun advanceTimeline(deltaMs: Long) {
+        timelineMsState.longValue += deltaMs
+    }
+}

--- a/confettikit/src/commonMain/kotlin/io/github/vinceglb/confettikit/core/PartySystem.kt
+++ b/confettikit/src/commonMain/kotlin/io/github/vinceglb/confettikit/core/PartySystem.kt
@@ -4,6 +4,7 @@ import io.github.vinceglb.confettikit.core.emitter.BaseEmitter
 import io.github.vinceglb.confettikit.core.emitter.Confetti
 import io.github.vinceglb.confettikit.core.emitter.PartyEmitter
 import io.github.vinceglb.confettikit.core.models.CoreRect
+import kotlin.random.Random
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
@@ -13,16 +14,19 @@ import kotlin.time.ExperimentalTime
  * @param party configuration class with instructions on how to create the particles for the Emitter
  * @param createdAt timestamp of when the partySystem is created
  * @param pixelDensity default value taken from resources to measure based on pixelDensity
+ * @param random source of randomness used by the emitter for color, shape, size, angle, speed and
+ * rotation jitter. Defaults to [Random.Default]; pass a seeded [Random] for deterministic output.
  */
 @OptIn(ExperimentalTime::class)
 public class PartySystem(
     public val party: Party,
     public val createdAt: Long = Clock.System.now().toEpochMilliseconds(),
     pixelDensity: Float,
+    random: Random = Random.Default,
 ) {
     private var enabled = true
 
-    private var emitter: BaseEmitter = PartyEmitter(party.emitter, pixelDensity)
+    private var emitter: BaseEmitter = PartyEmitter(party.emitter, pixelDensity, random)
 
     private val activeParticles = mutableListOf<Confetti>()
 
@@ -49,7 +53,8 @@ public class PartySystem(
      * @return true if the emitter is done emitting or false when it's still busy or needs to start
      * based on the delay
      */
-    internal fun isDoneEmitting(): Boolean = (emitter.isFinished() && activeParticles.size == 0) || (!enabled && activeParticles.size == 0)
+    internal fun isDoneEmitting(): Boolean =
+        (emitter.isFinished() && activeParticles.isEmpty()) || (!enabled && activeParticles.isEmpty())
 
     internal fun getActiveParticleAmount() = activeParticles.size
 }

--- a/confettikit/src/commonMain/kotlin/io/github/vinceglb/confettikit/core/emitter/EmitterConfig.kt
+++ b/confettikit/src/commonMain/kotlin/io/github/vinceglb/confettikit/core/emitter/EmitterConfig.kt
@@ -3,52 +3,48 @@ package io.github.vinceglb.confettikit.core.emitter
 import kotlin.time.Duration
 
 /**
- * Emitter class that holds the duration that the emitter will create confetti particles
+ * Helper class that holds the emission window and produces an [EmitterConfig].
  */
 public data class Emitter(
     val duration: Duration,
 ) {
     /**
-     * Max amount of particles that will be created over the duration that is set
+     * Spread [amount] particles evenly across the emission window.
      */
-    public fun max(amount: Int): EmitterConfig = EmitterConfig(this).max(amount)
+    public fun max(amount: Int): EmitterConfig {
+        val emittingTimeMs = duration.inWholeMilliseconds
+        return EmitterConfig(
+            emittingTime = emittingTimeMs,
+            amountPerMs = (emittingTimeMs.toFloat() / amount) / 1000f,
+        )
+    }
 
     /**
-     * Amount of particles that will be created per second
+     * Emit [amount] particles per second for the duration of the window.
      */
-    public fun perSecond(amount: Int): EmitterConfig = EmitterConfig(this).perSecond(amount)
+    public fun perSecond(amount: Int): EmitterConfig {
+        return EmitterConfig(
+            emittingTime = duration.inWholeMilliseconds,
+            amountPerMs = 1f / amount,
+        )
+    }
 }
 
 /**
- * EmitterConfig class that will gold the Emitter configuration and amount of particles that
- * will be created over certain time
+ * Immutable emitter configuration.
+ *
+ * Construct via [Emitter.max] or [Emitter.perSecond]; derive variants with [copy]. Being a
+ * data class makes any [io.github.vinceglb.confettikit.core.Party] containing this config
+ * structurally equatable, which lets [io.github.vinceglb.confettikit.compose.ConfettiKit]
+ * skip rebuilding particle systems on recompositions whose parties list is materially
+ * unchanged.
+ *
+ * @property emittingTime maximum time in milliseconds for the emitter to produce particles.
+ * A value of `0` means it will continue indefinitely.
+ * @property amountPerMs number of seconds between each particle creation. Lower values mean
+ * more frequent emissions.
  */
-public class EmitterConfig(
-    emitter: Emitter,
-) {
-    /** Max time allowed to emit in milliseconds */
-    public var emittingTime: Long = 0
-
-    /** Amount of time needed for each particle creation in milliseconds */
-    public var amountPerMs: Float = 0f
-
-    init {
-        this.emittingTime = emitter.duration.inWholeMilliseconds
-    }
-
-    /**
-     * Amount of particles created over the duration that is set
-     */
-    public fun max(amount: Int): EmitterConfig {
-        this.amountPerMs = (emittingTime.toFloat() / amount) / 1000f
-        return this
-    }
-
-    /**
-     * Amount of particles that will be created per second
-     */
-    public fun perSecond(amount: Int): EmitterConfig {
-        this.amountPerMs = 1f / amount
-        return this
-    }
-}
+public data class EmitterConfig(
+    val emittingTime: Long,
+    val amountPerMs: Float,
+)

--- a/confettikit/src/commonTest/kotlin/io/github/vinceglb/confettikit/compose/ConfettiKitStateTest.kt
+++ b/confettikit/src/commonTest/kotlin/io/github/vinceglb/confettikit/compose/ConfettiKitStateTest.kt
@@ -1,0 +1,243 @@
+package io.github.vinceglb.confettikit.compose
+
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+internal class ConfettiKitStateTest {
+
+    @Test
+    fun `pause and resume toggle isPaused`() {
+        val state = ConfettiKitState { Random.Default }
+
+        assertFalse(state.isPaused)
+
+        state.pause()
+        assertTrue(state.isPaused)
+
+        state.resume()
+        assertFalse(state.isPaused)
+    }
+
+    @Test
+    fun `advance accumulates pending delta and is consumed once`() {
+        val state = ConfettiKitState { Random.Default }
+
+        state.advance(100L)
+        state.advance(50L)
+
+        assertEquals(150L, state.takePendingAdvance())
+        assertEquals(0L, state.takePendingAdvance(), "second take should be empty")
+    }
+
+    @Test
+    fun `advance rejects negative deltas`() {
+        val state = ConfettiKitState { Random.Default }
+        assertFailsWith<IllegalArgumentException> { state.advance(-1L) }
+    }
+
+    @Test
+    fun `advanceTimeline updates timelineMs`() {
+        val state = ConfettiKitState { Random.Default }
+
+        assertEquals(0L, state.timelineMs)
+        state.advanceTimeline(250L)
+        assertEquals(250L, state.timelineMs)
+        state.advanceTimeline(750L)
+        assertEquals(1000L, state.timelineMs)
+    }
+
+    @Test
+    fun `reset clears timeline and pending advance and bumps reset signal`() {
+        val state = ConfettiKitState { Random.Default }
+
+        state.advance(500L)
+        state.advanceTimeline(1000L)
+        val signalBefore = state.resetSignal.intValue
+
+        state.reset()
+
+        assertEquals(0L, state.timelineMs)
+        assertEquals(0L, state.takePendingAdvance())
+        assertEquals(signalBefore + 1, state.resetSignal.intValue)
+    }
+
+    @Test
+    fun `reset re-creates Random via factory`() {
+        var calls = 0
+        val state = ConfettiKitState {
+            calls++
+            Random(42L)
+        }
+
+        val first = state.random
+        assertEquals(1, calls, "factory called once on construction")
+
+        state.reset()
+
+        val second = state.random
+        assertEquals(2, calls, "factory called again on reset")
+        assertNotSame(first, second, "random instance should be a fresh one")
+    }
+
+    @Test
+    fun `seeded factory produces deterministic Random sequence after reset`() {
+        val state = ConfettiKitState { Random(42L) }
+
+        val firstRun = List(10) { state.random.nextInt() }
+        state.reset()
+        val secondRun = List(10) { state.random.nextInt() }
+
+        assertEquals(firstRun, secondRun)
+    }
+
+    @Test
+    fun `default factory yields the singleton Random Default`() {
+        val state = ConfettiKitState { Random.Default }
+        assertSame(Random.Default, state.random)
+    }
+
+    @Test
+    fun `advanceTo forward queues pending advance`() {
+        val state = ConfettiKitState { Random.Default }
+
+        state.advanceTo(500L)
+
+        assertEquals(0L, state.timelineMs, "timeline only advances on frame, not on advanceTo")
+        assertEquals(500L, state.takePendingAdvance())
+    }
+
+    @Test
+    fun `advanceTo backward triggers reset and queues advance to target`() {
+        val state = ConfettiKitState { Random.Default }
+        state.advanceTimeline(2000L)
+
+        state.advanceTo(500L)
+
+        assertEquals(0L, state.timelineMs)
+        assertEquals(500L, state.takePendingAdvance())
+    }
+
+    @Test
+    fun `advanceTo rejects negative target`() {
+        val state = ConfettiKitState { Random.Default }
+        assertFailsWith<IllegalArgumentException> { state.advanceTo(-1L) }
+    }
+
+    @Test
+    fun `advanceTo at current position queues nothing`() {
+        val state = ConfettiKitState { Random.Default }
+        state.advanceTimeline(1000L)
+
+        state.advanceTo(1000L)
+
+        assertEquals(1000L, state.timelineMs)
+        assertEquals(0L, state.takePendingAdvance())
+    }
+
+    @Test
+    fun `setRandomFactory swaps factory without resetting`() {
+        val state = ConfettiKitState { Random.Default }
+        state.advanceTimeline(2000L)
+        state.advance(500L)
+        val signalBefore = state.resetSignal.intValue
+
+        state.setRandomFactory { Random(7L) }
+
+        assertEquals(2000L, state.timelineMs, "timeline preserved")
+        assertEquals(500L, state.takePendingAdvance(), "pending preserved")
+        assertEquals(signalBefore, state.resetSignal.intValue, "no reset signal")
+
+        // The next explicit reset pulls from the new factory.
+        state.reset()
+        val firstSeq = List(5) { state.random.nextInt() }
+        state.reset()
+        val secondSeq = List(5) { state.random.nextInt() }
+        assertEquals(firstSeq, secondSeq, "new factory should be reproducible")
+    }
+
+    @Test
+    fun `useRandom swaps factory and resets`() {
+        val state = ConfettiKitState { Random.Default }
+        state.advanceTimeline(2000L)
+        state.advance(500L)
+        val signalBefore = state.resetSignal.intValue
+
+        state.useRandom { Random(123L) }
+
+        assertEquals(0L, state.timelineMs)
+        assertEquals(0L, state.takePendingAdvance())
+        assertEquals(signalBefore + 1, state.resetSignal.intValue)
+
+        // Subsequent reset uses the new factory
+        val firstSeq = List(5) { state.random.nextInt() }
+        state.reset()
+        val secondSeq = List(5) { state.random.nextInt() }
+        assertEquals(firstSeq, secondSeq, "new factory should produce reproducible sequences")
+    }
+
+    @Test
+    fun `advanceTo trims pending without resetting when backward fits within queued advance`() {
+        // Slider drag fired multiple advanceTo calls between two frames; the latest landed
+        // behind the effective position but inside the not-yet-committed queue.
+        val state = ConfettiKitState { Random.Default }
+        state.advanceTo(1000L) // pending = 1000
+        val signalBefore = state.resetSignal.intValue
+
+        state.advanceTo(200L) // backward 800, fits within pending=1000
+
+        assertEquals(0L, state.timelineMs, "timeline untouched")
+        assertEquals(
+            200L,
+            state.takePendingAdvance(),
+            "pending trimmed so effective lands at target"
+        )
+        assertEquals(signalBefore, state.resetSignal.intValue, "no reset signal incremented")
+    }
+
+    @Test
+    fun `advanceTo trims small backward within pending`() {
+        val state = ConfettiKitState { Random.Default }
+        state.advanceTo(1000L) // pending = 1000
+        val signalBefore = state.resetSignal.intValue
+
+        state.advanceTo(990L) // backward 10, fits
+
+        assertEquals(0L, state.timelineMs)
+        assertEquals(990L, state.takePendingAdvance())
+        assertEquals(signalBefore, state.resetSignal.intValue)
+    }
+
+    @Test
+    fun `advanceTo resets when backward exceeds queued advance`() {
+        // Once a frame has committed pending into timelineMs, pending=0, and any backward
+        // intent must reset — there is no way to undo committed timeline without it.
+        val state = ConfettiKitState { Random.Default }
+        state.advanceTimeline(1000L) // committed timeline, pending=0
+        val signalBefore = state.resetSignal.intValue
+
+        state.advanceTo(900L) // backward 100, pending=0 cannot absorb
+
+        assertEquals(0L, state.timelineMs)
+        assertEquals(900L, state.takePendingAdvance())
+        assertEquals(signalBefore + 1, state.resetSignal.intValue)
+    }
+
+    @Test
+    fun `advanceTo to zero from committed timeline always lands at zero`() {
+        // Regression: with a fixed-ms tolerance, advancing to 0 from a small committed
+        // timelineMs would no-op the trim (pending=0), leaving timelineMs unchanged.
+        val state = ConfettiKitState { Random.Default }
+        state.advanceTimeline(10L) // small committed timeline, pending=0
+
+        state.advanceTo(0L)
+
+        assertEquals(0L, state.timelineMs, "must hard-land at zero")
+        assertEquals(0L, state.takePendingAdvance())
+    }
+}

--- a/confettikit/src/commonTest/kotlin/io/github/vinceglb/confettikit/compose/ConfettiKitStateTest.kt
+++ b/confettikit/src/commonTest/kotlin/io/github/vinceglb/confettikit/compose/ConfettiKitStateTest.kt
@@ -25,6 +25,31 @@ internal class ConfettiKitStateTest {
     }
 
     @Test
+    fun `initiallyPaused seeds isPaused at construction`() {
+        val paused = ConfettiKitState(initiallyPaused = true) { Random.Default }
+        assertTrue(paused.isPaused)
+
+        val live = ConfettiKitState(initiallyPaused = false) { Random.Default }
+        assertFalse(live.isPaused)
+    }
+
+    @Test
+    fun `initialTimelineMs seeds pending advance at construction`() {
+        val state = ConfettiKitState(initialTimelineMs = 2_000L) { Random.Default }
+
+        // The advance is queued, not applied — timelineMs only moves on the next frame.
+        assertEquals(0L, state.timelineMs)
+        assertEquals(2_000L, state.takePendingAdvance())
+    }
+
+    @Test
+    fun `initialTimelineMs rejects negative values`() {
+        assertFailsWith<IllegalArgumentException> {
+            ConfettiKitState(initialTimelineMs = -1L) { Random.Default }
+        }
+    }
+
+    @Test
     fun `advance accumulates pending delta and is consumed once`() {
         val state = ConfettiKitState { Random.Default }
 

--- a/confettikit/src/commonTest/kotlin/io/github/vinceglb/confettikit/core/PartyEqualityTest.kt
+++ b/confettikit/src/commonTest/kotlin/io/github/vinceglb/confettikit/core/PartyEqualityTest.kt
@@ -1,0 +1,45 @@
+package io.github.vinceglb.confettikit.core
+
+import io.github.vinceglb.confettikit.core.emitter.Emitter
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Regression coverage for the `EmitterConfig`-as-data-class refactor: a [Party] built twice
+ * from the same arguments must be structurally equal so that re-keying compose effects on a
+ * `List<Party>` doesn't fire on every recomposition.
+ */
+internal class PartyEqualityTest {
+
+    @Test
+    fun `two parties built from the same arguments are equal`() {
+        val a = Party(emitter = Emitter(1.seconds).max(100))
+        val b = Party(emitter = Emitter(1.seconds).max(100))
+
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+
+    @Test
+    fun `parties differing only in emitter config are not equal`() {
+        val a = Party(emitter = Emitter(1.seconds).max(100))
+        val b = Party(emitter = Emitter(1.seconds).max(50))
+
+        kotlin.test.assertNotEquals(a, b)
+    }
+
+    @Test
+    fun `lists of equal parties are equal`() {
+        val left = listOf(
+            Party(emitter = Emitter(1.seconds).perSecond(30)),
+            Party(emitter = Emitter(2.seconds).max(200)),
+        )
+        val right = listOf(
+            Party(emitter = Emitter(1.seconds).perSecond(30)),
+            Party(emitter = Emitter(2.seconds).max(200)),
+        )
+
+        assertEquals(left, right)
+    }
+}

--- a/confettikit/src/commonTest/kotlin/io/github/vinceglb/confettikit/core/PartySystemRandomTest.kt
+++ b/confettikit/src/commonTest/kotlin/io/github/vinceglb/confettikit/core/PartySystemRandomTest.kt
@@ -1,0 +1,59 @@
+package io.github.vinceglb.confettikit.core
+
+import io.github.vinceglb.confettikit.core.emitter.Emitter
+import io.github.vinceglb.confettikit.core.models.CoreRect
+import io.github.vinceglb.confettikit.core.models.Shape
+import io.github.vinceglb.confettikit.core.models.Size
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+internal class PartySystemRandomTest {
+    private val drawArea = CoreRect.CoreRectImpl(width = 1000f, height = 1000f)
+
+    private fun party(): Party = Party(
+        emitter = Emitter(1.seconds).perSecond(amount = 30),
+        position = Position.Absolute(500f, 500f),
+        spread = 360,
+        speed = 5f,
+        maxSpeed = 20f,
+        damping = 0.9f,
+        rotation = Rotation.enabled(),
+        shapes = listOf(Shape.Square, Shape.Circle),
+        colors = listOf(0xff0000, 0x00ff00, 0x0000ff),
+        size = listOf(Size.SMALL, Size.MEDIUM, Size.LARGE),
+        timeToLive = 5_000,
+        fadeOutEnabled = false,
+    )
+
+    private fun renderFrames(system: PartySystem, frames: Int, deltaSeconds: Float = 1f / 60f) =
+        (0 until frames).flatMap { system.render(deltaSeconds, drawArea) }
+
+    @Test
+    fun `same seeded Random produces identical particle output`() {
+        val systemA = PartySystem(party = party(), pixelDensity = 1f, random = Random(42L))
+        val systemB = PartySystem(party = party(), pixelDensity = 1f, random = Random(42L))
+
+        val a = renderFrames(systemA, frames = 30)
+        val b = renderFrames(systemB, frames = 30)
+
+        assertTrue(a.isNotEmpty(), "expected particles to be produced")
+        assertEquals(a, b, "same seed should produce identical particle output")
+    }
+
+    @Test
+    fun `different seeds produce diverging output`() {
+        val systemA = PartySystem(party = party(), pixelDensity = 1f, random = Random(1L))
+        val systemB = PartySystem(party = party(), pixelDensity = 1f, random = Random(99999L))
+
+        val a = renderFrames(systemA, frames = 60)
+        val b = renderFrames(systemB, frames = 60)
+
+        assertTrue(a.isNotEmpty(), "expected particles to be produced for seed A")
+        assertTrue(b.isNotEmpty(), "expected particles to be produced for seed B")
+        assertNotEquals(a, b, "different seeds should produce different particle output")
+    }
+}

--- a/confettikit/src/commonTest/kotlin/io/github/vinceglb/confettikit/core/emitter/EmitterTest.kt
+++ b/confettikit/src/commonTest/kotlin/io/github/vinceglb/confettikit/core/emitter/EmitterTest.kt
@@ -2,6 +2,7 @@ package io.github.vinceglb.confettikit.core.emitter
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -39,5 +40,22 @@ internal class EmitterTest {
 
         assertEquals(expected = 100, actual = config.emittingTime)
         assertEquals(expected = 0.0001f, actual = config.amountPerMs, absoluteTolerance = TOLERANCE)
+    }
+
+    @Test
+    fun `two configs built from the same builder calls are structurally equal`() {
+        val a = Emitter(duration = 1.seconds).max(amount = 100)
+        val b = Emitter(duration = 1.seconds).max(amount = 100)
+
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+
+    @Test
+    fun `configs with different field values are not equal`() {
+        val a = Emitter(duration = 1.seconds).max(amount = 100)
+        val b = Emitter(duration = 1.seconds).max(amount = 50)
+
+        assertNotEquals(a, b)
     }
 }

--- a/sample/shared/src/commonMain/kotlin/io/github/vinceglb/confettikit/sample/App.kt
+++ b/sample/shared/src/commonMain/kotlin/io/github/vinceglb/confettikit/sample/App.kt
@@ -1,12 +1,18 @@
 package io.github.vinceglb.confettikit.sample
 
+import androidx.compose.animation.core.withInfiniteAnimationFrameMillis
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -18,16 +24,60 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.compose.animation.core.withInfiniteAnimationFrameMillis
 import io.github.vinceglb.confettikit.compose.ConfettiKit
+import io.github.vinceglb.confettikit.compose.rememberConfettiKitState
+import io.github.vinceglb.confettikit.core.Party
+import kotlin.random.Random
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeSource
+
+private const val REPLAY_SEED = 1234L
+
+/**
+ * Time at which every particle in this preset has finished fading: the latest of
+ * `delay + emitter.emittingTime + timeToLive (+ fadeOutDuration)` across all parties.
+ */
+private fun List<Party>.expectedDurationMs(): Long = maxOfOrNull { party ->
+    party.delay.toLong() +
+            party.emitter.emittingTime +
+            party.timeToLive +
+            (if (party.fadeOutEnabled) party.fadeOutDuration else 0L)
+} ?: 0L
 
 @Composable
 fun App() {
     var isAnimating by remember { mutableStateOf(false) }
     var index by remember { mutableStateOf(0) }
     var simulateLag by remember { mutableStateOf(false) }
+    var manualControl by remember { mutableStateOf(false) }
+    var scrubMs by remember { mutableStateOf(0f) }
+
+    val state = rememberConfettiKitState()
+    val presets = Presets.all()
+    // Cache the parties list per index so the reference is stable across recompositions.
+    // Without this, any non-stable Shape (e.g. a `class` with no equals override) would make
+    // each composition's parties list structurally unequal to the previous one, re-keying
+    // ConfettiKit's LaunchedEffect on every state change and visibly restarting the animation.
+    val currentParties = remember(index) { presets[index].second }
+    val animationDurationMs = remember(index) {
+        presets[index].second.expectedDurationMs().coerceAtLeast(1L)
+    }
+
+    // Manual control freezes whatever frame is currently on screen and exposes the slider.
+    // Both toggles use setRandomFactory (not useRandom) so the simulation is *not* reset on
+    // toggle — the live frame stays where it was. Determinism kicks in on the next explicit
+    // restart (preset button), at which point the queued seeded factory takes effect.
+    // Scrubbing backward also re-instantiates Random via the factory, so once the user drags
+    // back through any earlier timestamp the run becomes seeded from there onward.
+    LaunchedEffect(manualControl) {
+        if (manualControl) {
+            state.setRandomFactory { Random(REPLAY_SEED) }
+            state.pause()
+        } else {
+            state.setRandomFactory { Random.Default }
+            state.resume()
+        }
+    }
 
     if (simulateLag) {
         LaunchedEffect(Unit) {
@@ -48,16 +98,27 @@ fun App() {
             modifier = Modifier.fillMaxSize(),
         ) {
             Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
                 verticalArrangement = Arrangement.spacedBy(16.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Text("Hello ConfettiKit!")
 
-                Button(
-                    enabled = !isAnimating,
-                    onClick = { isAnimating = !isAnimating },
-                ) {
-                    Text("Fiesta 🥳")
+                presets.forEachIndexed { i, (name, _) ->
+                    Button(
+                        onClick = {
+                            // Switch to this preset, reset the simulation, snap the slider
+                            // back to 0, and mount the canvas. Clicking again restarts the
+                            // same preset; clicking another swaps to it (ConfettiKit re-keys
+                            // its frame loop on `parties`).
+                            index = i
+                            state.reset()
+                            scrubMs = 0f
+                            isAnimating = true
+                        },
+                    ) {
+                        Text(name)
+                    }
                 }
 
                 Row(
@@ -70,17 +131,62 @@ fun App() {
                         onCheckedChange = { simulateLag = it },
                     )
                 }
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text("Manual control")
+                    Switch(
+                        checked = manualControl,
+                        onCheckedChange = { enabled ->
+                            // Sync scrubMs to live playback BEFORE flipping manualControl, so
+                            // the displayValueMs computation in the same recomposition reads
+                            // the current position. Otherwise the slider snaps to the stale
+                            // scrubMs (often 0) and only catches up after the LaunchedEffect
+                            // runs async — visible as a back-and-forth jump on toggle on.
+                            if (enabled) {
+                                scrubMs = state.timelineMs.toFloat()
+                                    .coerceIn(0f, animationDurationMs.toFloat())
+                            }
+                            manualControl = enabled
+                        },
+                    )
+                }
+
+                // Always render the scrub controls. `enabled = manualControl` makes the slider
+                // non-interactive (and visually dimmed) when manual control is off, while
+                // keeping the layout stable. While disabled, bind the thumb to the live
+                // `state.timelineMs` so it tracks playback; while enabled, bind to `scrubMs`
+                // so the thumb follows the user's gesture without one-frame lag.
+                val displayValueMs = if (manualControl) {
+                    scrubMs
+                } else {
+                    state.timelineMs.toFloat().coerceIn(0f, animationDurationMs.toFloat())
+                }
+                Slider(
+                    value = displayValueMs,
+                    onValueChange = { value ->
+                        scrubMs = value
+                        state.advanceTo(value.toLong())
+                    },
+                    enabled = manualControl,
+                    valueRange = 0f..animationDurationMs.toFloat(),
+                    modifier = Modifier
+                        .fillMaxWidth(0.8f)
+                        .padding(horizontal = 32.dp),
+                )
+                Text("${displayValueMs.toLong()} / $animationDurationMs ms")
             }
 
             if (isAnimating) {
-                val presets = Presets.all()
                 ConfettiKit(
                     modifier = Modifier.fillMaxSize(),
-                    parties = presets[index],
+                    parties = currentParties,
+                    state = state,
                     onParticleSystemEnded = { _, activeSystems ->
-                        if (activeSystems == 0 && isAnimating) {
+                        if (activeSystems == 0 && isAnimating && !manualControl) {
                             isAnimating = false
-                            index = (index + 1) % presets.size
                         }
                     },
                 )

--- a/sample/shared/src/commonMain/kotlin/io/github/vinceglb/confettikit/sample/HeartShape.kt
+++ b/sample/shared/src/commonMain/kotlin/io/github/vinceglb/confettikit/sample/HeartShape.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 
-class HeartShape: Shape {
+object HeartShape : Shape {
     override fun createOutline(
         size: Size,
         layoutDirection: LayoutDirection,

--- a/sample/shared/src/commonMain/kotlin/io/github/vinceglb/confettikit/sample/Presets.kt
+++ b/sample/shared/src/commonMain/kotlin/io/github/vinceglb/confettikit/sample/Presets.kt
@@ -31,7 +31,7 @@ class Presets {
                     colors = listOf(0xfce18a, 0xff726d, 0xf4306d, 0xb48def),
                     shapes = listOf(
                         Shape.CustomShape(CircleShape),
-                        Shape.CustomShape(HeartShape()),
+                        Shape.CustomShape(HeartShape),
                         Shape.CustomShape(RoundedCornerShape(5.dp))
                     ),
                     emitter = Emitter(duration = 100.milliseconds).max(100),
@@ -81,10 +81,10 @@ class Presets {
         }
 
         @Composable
-        fun all() = listOf(
-            explode(),
-            parade(),
-            rain(),
+        fun all(): List<Pair<String, List<Party>>> = listOf(
+            "Explode 💥" to explode(),
+            "Parade 🎉" to parade(),
+            "Rain 🌧" to rain(),
         )
     }
 }


### PR DESCRIPTION
- Implement `ConfettiKitState` and `rememberConfettiKitState` to enable external control over the confetti simulation.
- Add support for pausing, resuming, resetting, and manual scrubbing (seeking) via `advanceTo`.
- Introduce deterministic playback support by allowing custom `Random` factories in `ConfettiKitState`.
- Refactor `EmitterConfig` into a data class to ensure structural equality, preventing unnecessary simulation restarts during recomposition.
- Implement physics sub-stepping in `ConfettiKit` to maintain simulation stability during large manual time deltas.
- Update the sample app with a preset gallery and interactive manual control UI.
- Add comprehensive tests for state management, structural equality, and deterministic output.

https://github.com/user-attachments/assets/232ba9ab-ec27-4e5a-a4d8-f0ae9366395d
